### PR TITLE
PgUp / PgDown ==> Up / Down

### DIFF
--- a/visualizer/js/Util.js
+++ b/visualizer/js/Util.js
@@ -60,6 +60,8 @@ Math.dist_2 = function(x1, y1, x2, y2, w, h) {
 var Key = {
 	LEFT : 37,
 	RIGHT : 39,
+    UP : 38,
+    DOWN : 40,
 	SPACE : 32,
 	PGUP : 33,
 	PGDOWN : 34,

--- a/visualizer/js/VisApplication.js
+++ b/visualizer/js/VisApplication.js
@@ -1314,10 +1314,10 @@ VisApplication.prototype.keyPressed = function(key) {
 	if (!this.state.options['embedded']) {
 		tryOthers = false;
 		switch (key) {
-		case Key.PGUP:
+		case Key.DOWN:
 			d.gotoTick(Math.ceil(visState.time) - 10);
 			break;
-		case Key.PGDOWN:
+		case Key.UP:
 			d.gotoTick(Math.floor(visState.time) + 10);
 			break;
 		case Key.HOME:


### PR DESCRIPTION
|key |feature         |
|:---------------|:----------------------------|
| → | 1 turn forward         |
| ← | 1 turn backwards     |
| ↑ | 10 turns forward| 
| ↓|  10 turns backwards |
|HOME |   to the start              |
|END |  to the end                |
|+  | speed increase         | 
|-   |   speed decrease     |  
|SPACE  |  start/stop playback  |
|C |  center map              |
|F  | toggle Fullscreen      | 
|I  |  generate bot input |

PgUp and PgDown can have different codes depending on OS, browser and Numpad state. So this is easier to use normal arrows instead.

